### PR TITLE
Revise libre source and port

### DIFF
--- a/ports/libre/portfile.cmake
+++ b/ports/libre/portfile.cmake
@@ -1,3 +1,6 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -5,13 +8,12 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 fce61b96fd4a330c82045c470486e90e1128e242b7c311e9c6002d9752b775bbc430bf256de85f63841172c60630be3aa91e11bfa1501c71599d213701c6b459
     HEAD_REF main
+    PATCHES
+        wip.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" LIBRE_BUILD_SHARED)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" LIBRE_BUILD_STATIC)
-
-set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
-set(VCPKG_POLICY_DLLS_WITHOUT_EXPORTS enabled)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -22,14 +24,11 @@ vcpkg_cmake_configure(
         -DCMAKE_REQUIRE_FIND_PACKAGE_OpenSSL=ON
         -DCMAKE_REQUIRE_FIND_PACKAGE_ZLIB=ON
 )
-
 vcpkg_cmake_install()
-
 vcpkg_fixup_pkgconfig()
-
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/re PACKAGE_NAME re)
-
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libre)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libre/usage
+++ b/ports/libre/usage
@@ -1,4 +1,5 @@
-The package libre is compatible with built-in CMake targets:
+libre provides CMake targets:
 
-    find_package(re CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE re)
+    find_package(libre CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE libre::libre)
+    

--- a/ports/libre/wip.patch
+++ b/ports/libre/wip.patch
@@ -1,0 +1,155 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f85cb1e..a6286c9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -92,8 +92,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+   set_source_files_properties(src/mem/mem.c PROPERTIES COMPILE_FLAGS -Wpadded)
+ endif()
+ 
+-set(re_DIR ${CMAKE_CURRENT_LIST_DIR}/cmake)
+-find_package(re CONFIG REQUIRED)
++include("${CMAKE_CURRENT_LIST_DIR}/cmake/re-config.cmake")
+ 
+ list(APPEND RE_DEFINITIONS
+   -DVERSION="${PROJECT_VERSION_FULL}"
+@@ -642,7 +641,7 @@ if(WIN32)
+     dbghelp
+   )
+ else()
+-  list(APPEND LINKLIBS -lm)
++  list(APPEND LINKLIBS m)
+ endif()
+ 
+ if(UNIX)
+@@ -668,7 +667,7 @@ target_include_directories(re-objs PRIVATE
+   ${OPENSSL_INCLUDE_DIR} ${ZLIB_INCLUDE_DIRS})
+ target_include_directories(re-objs PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+-    $<INSTALL_INTERFACE:include>
++    $<INSTALL_INTERFACE:include> # pointless, object libs don't get installed.
+   )
+ 
+ 
+@@ -697,11 +696,14 @@ endif()
+ if(LIBRE_BUILD_STATIC)
+   list(APPEND RE_INSTALL_TARGETS re)
+   add_library(re STATIC $<TARGET_OBJECTS:re-objs>)
+-  target_link_libraries(re PUBLIC ${LINKLIBS})
++  target_link_libraries(re PRIVATE ${LINKLIBS})
+   add_library(libre::re ALIAS re)
+ 
+   if(MSVC)
+     set_target_properties(re PROPERTIES OUTPUT_NAME "re-static")
++    if(NOT LIBRE_BUILD_SHARED)
++      set(PC_LIBNAME "re-static")
++    endif()
+   endif()
+ endif()
+ 
+@@ -714,6 +716,28 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+   add_subdirectory(packaging)
+ endif()
+ 
++if(NOT PC_LIBNAME)
++  set(PC_LIBNAME "re")
++endif()
++set(PC_REQUIRES "")
++set(PC_LINKLIBS "")
++foreach(item IN LISTS LINKLIBS)
++  if(item STREQUAL "Threads::Threads")
++    list(APPEND PC_LINKLIBS ${CMAKE_THREADS_LIBS_INIT})
++  elseif(item STREQUAL "OpenSSL::Crypto")
++    list(APPEND PC_REQUIRES "libcrypto")
++  elseif(item STREQUAL "OpenSSL::SSL")
++    list(APPEND PC_REQUIRES "libssl")
++  elseif(item STREQUAL "ZLIB::ZLIB")
++    list(APPEND PC_REQUIRES "zlib")
++  elseif(item MATCHES "^-|/")
++    list(APPEND PC_LINKLIBS "${item}")
++  else()
++    list(APPEND PC_LINKLIBS "-l${item}")
++  endif()
++endforeach()
++list(JOIN PC_LINKLIBS " " PC_LINKLIBS)
++list(JOIN PC_REQUIRES " " PC_REQUIRES)
+ configure_file(packaging/libre.pc.in libre.pc @ONLY)
+ 
+ 
+@@ -725,6 +749,9 @@ configure_file(packaging/libre.pc.in libre.pc @ONLY)
+ 
+ install(TARGETS ${RE_INSTALL_TARGETS}
+   EXPORT libre
++  RUNTIME
++    DESTINATION ${CMAKE_INSTALL_BINDIR}
++    COMPONENT Libraries
+   LIBRARY
+     DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     COMPONENT Libraries
+@@ -743,7 +770,9 @@ install(FILES ${HEADERS}
+ 
+ install(EXPORT libre
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libre
++  FILE libre-targets.cmake
+   NAMESPACE libre::
++  COMPONENT Development
+ )
+ 
+ if(LIBRE_BUILD_SHARED)
+@@ -755,12 +784,8 @@ if(LIBRE_BUILD_SHARED)
+   )
+ endif()
+ 
+-install(FILES cmake/re-config.cmake
+-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/re
+-  COMPONENT Development
+-)
+-
+-install(FILES cmake/libre-config.cmake
++configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/libre-config.cmake" "${CMAKE_CURRENT_BINARY_DIR}/cmake/libre-config.cmake" @ONLY)
++install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake/libre-config.cmake"
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libre
+   COMPONENT Development
+ )
+diff --git a/cmake/libre-config.cmake b/cmake/libre-config.cmake
+index 0965b84..af7f2de 100644
+--- a/cmake/libre-config.cmake
++++ b/cmake/libre-config.cmake
+@@ -1 +1,23 @@
+-include("${CMAKE_CURRENT_LIST_DIR}/libre.cmake")
++if("@LIBRE_BUILD_STATIC@")
++    include(CMakeFindDependencyMacro)
++    find_dependency(Threads)
++    if("@USE_OPENSSL@")
++        find_dependency(OpenSSL)
++    endif()
++    if("@ZLIB_FOUND@")
++        find_dependency(ZLIB)
++    endif()
++endif()
++
++include("${CMAKE_CURRENT_LIST_DIR}/libre-targets.cmake")
++
++# convenience target libre::libre for uniform usage
++if(NOT TARGET libre::libre)
++    if(TARGET libre::re_shared AND (BUILD_SHARED_LIBS OR NOT TARGET libre::re))
++        add_library(libre::libre INTERFACE IMPORTED)
++        set_target_properties(libre::libre PROPERTIES INTERFACE_LINK_LIBRARIES libre::re_shared)
++    elseif(TARGET libre::re AND (NOT BUILD_SHARED_LIBS OR NOT TARGET libre::re_shared))
++        add_library(libre::libre INTERFACE IMPORTED)
++        set_target_properties(libre::libre PROPERTIES INTERFACE_LINK_LIBRARIES libre::re_shared)
++    endif()
++endif()
+diff --git a/packaging/libre.pc.in b/packaging/libre.pc.in
+index 5817066..9389435 100644
+--- a/packaging/libre.pc.in
++++ b/packaging/libre.pc.in
+@@ -7,6 +7,7 @@ Name: libre
+ Description: @CMAKE_PROJECT_DESCRIPTION@
+ Version: @PROJECT_VERSION@
+ URL: @CMAKE_PROJECT_HOMEPAGE_URL@
+-Libs: -L${libdir} -lre
+-Libs.private: -L${libdir} -lre -ldl -lssl -lcrypto -lz -lpthread
++Libs: -L${libdir} -lre@PC_LIBNAME_SUFFIX@
++Libs.private: @PC_LINKLIBS@
++Requires.private: @PC_REQUIRES@
+ Cflags: -I${includedir}


### PR DESCRIPTION
The major contribution is `wip.patch` which is the set of changes to be upstreamed. It covers:
- Fixes for installation.
- Fixes for CMake config export.
- Fixes for pkg-config files.

What I didn't discover is the required definitions (dllexport/dllimport or def file) for creating proper DLLs on Windows. If I didn't miss it, I would say DLLs are not supported.